### PR TITLE
feat: open in web functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ecs-log-viewer [options]
 - `--region, -r`: AWS region to use (can also be set via AWS_REGION environment variable)
 - `--duration, -d`: Duration to fetch logs for (e.g., 24h, 1h, 30m) (default: 24h)
 - `--filter, -f`: String pattern to filter log messages
+- `--web`: Start in web mode, launching a web interface instead of CLI
 
 ### Example
 
@@ -70,6 +71,12 @@ ecs-log-viewer --duration 1h
 
 # View logs containing specific text
 ecs-log-viewer --filter "error"
+
+# Start in web mode
+ecs-log-viewer --web
+
+# Start web mode with filter and duration options
+ecs-log-viewer --web --filter "error" --duration 2h
 ```
 
 ## Dependencies

--- a/cmd/ecs-log-viewer/app.go
+++ b/cmd/ecs-log-viewer/app.go
@@ -105,7 +105,7 @@ func runApp(c *cli.Context) error {
 	query := cloudwatchclient.BuildCloudWatchQuery(logStreamPrefix, runOption.filter)
 
 	if runOption.web {
-		consoleURL := cloudwatchclient.BuildConsoleURL(cfg.Region, logGroup, query)
+		consoleURL := cloudwatchclient.BuildConsoleURL(cfg.Region, logGroup, query, runOption.duration)
 		fmt.Printf("Opening AWS Console URL: %s\n", consoleURL)
 		return openBrowser(consoleURL)
 	}
@@ -142,16 +142,14 @@ func openBrowser(url string) error {
 }
 
 func open(url string) error {
-	var err error = nil
 	switch {
 	case runtime.GOOS == "linux":
-		err = exec.Command("xdg-open", url).Start()
+		return exec.Command("xdg-open", url).Start()
 	case runtime.GOOS == "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	case runtime.GOOS == "darwin":
-		err = exec.Command("open", url).Start()
+		return exec.Command("open", url).Start()
 	default:
-		err = fmt.Errorf("unsupported platform")
+		return fmt.Errorf("unsupported platform")
 	}
-	return err
 }

--- a/cmd/ecs-log-viewer/app.go
+++ b/cmd/ecs-log-viewer/app.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"runtime"
 	"sort"
 	"time"
 
@@ -21,6 +23,7 @@ type AppOption struct {
 	region   string
 	duration time.Duration
 	filter   string
+	web      bool
 }
 
 func newAppOption(c *cli.Context) AppOption {
@@ -29,6 +32,7 @@ func newAppOption(c *cli.Context) AppOption {
 		region:   c.String("region"),
 		duration: c.Duration("duration"),
 		filter:   c.String("filter"),
+		web:      c.Bool("web"),
 	}
 }
 
@@ -98,8 +102,16 @@ func runApp(c *cli.Context) error {
 	fmt.Printf("Fetching logs from log group: %s, stream prefix: %s\n", logGroup, logStreamPrefix)
 	fmt.Printf("Time range: %s to %s\n", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
 
+	query := cloudwatchclient.BuildCloudWatchQuery(logStreamPrefix, runOption.filter)
+
+	if runOption.web {
+		consoleURL := cloudwatchclient.BuildConsoleURL(cfg.Region, logGroup, query)
+		fmt.Printf("Opening AWS Console URL: %s\n", consoleURL)
+		return openBrowser(consoleURL)
+	}
+
 	// Query logs using the new method
-	results, err := logsClient.QueryLogsByStreamPrefix(logGroup, logStreamPrefix, startTime, endTime, runOption.filter)
+	results, err := logsClient.QueryLogs(logGroup, query, startTime, endTime)
 	if err != nil {
 		return fmt.Errorf("failed to query logs: %v", err)
 	}
@@ -123,4 +135,23 @@ func runApp(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+func openBrowser(url string) error {
+	return open("https://" + url)
+}
+
+func open(url string) error {
+	var err error = nil
+	switch {
+	case runtime.GOOS == "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case runtime.GOOS == "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case runtime.GOOS == "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	return err
 }

--- a/cmd/ecs-log-viewer/main.go
+++ b/cmd/ecs-log-viewer/main.go
@@ -36,6 +36,12 @@ func main() {
 				Aliases: []string{"f"},
 				Usage:   "Filter logs by keyword",
 			},
+			&cli.BoolFlag{
+				Name:    "web",
+				Aliases: []string{"w"},
+				Usage:   "Open logs in AWS Console instead of terminal",
+				Value:   false,
+			},
 		},
 		Action: runApp,
 	}

--- a/pkg/cloudwatchclient/client.go
+++ b/pkg/cloudwatchclient/client.go
@@ -91,9 +91,8 @@ type QueryResult struct {
 	Message       string
 }
 
-// QueryLogsByStreamPrefix queries logs from streams matching the prefix within the specified time range
-func (c *CloudWatchClient) QueryLogsByStreamPrefix(logGroup, streamPrefix string, startTime, endTime time.Time, filter string) ([]QueryResult, error) {
-	query := buildCloudWatchQuery(streamPrefix, filter)
+// QueryLogs queries logs from streams matching the prefix within the specified time range
+func (c *CloudWatchClient) QueryLogs(logGroup, query string, startTime, endTime time.Time) ([]QueryResult, error) {
 
 	// Start the query
 	startQueryInput := &cw.StartQueryInput{

--- a/pkg/cloudwatchclient/console_url.go
+++ b/pkg/cloudwatchclient/console_url.go
@@ -3,20 +3,22 @@ package cloudwatchclient
 import (
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // BuildConsoleURL generates AWS Console URL for CloudWatch Logs Insights
 // query parameter should be a valid CloudWatch Logs Insights query
 // e.g. "fields @timestamp, @message | sort @timestamp desc | limit 1000"
-func BuildConsoleURL(region, logGroup, query string) string {
+func BuildConsoleURL(region, logGroup, query string, duration time.Duration) string {
 	// URL encode the log group and query
 	encodedLogGroup := url.QueryEscape(logGroup)
 	encodedQuery := url.QueryEscape(query)
 
 	// Construct the URL with the Logs Insights format
-	return fmt.Sprintf("%s.console.aws.amazon.com/cloudwatch/home?region=%s#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'%s~source~(~'%s)~lang~'CWLI)",
+	return fmt.Sprintf("%s.console.aws.amazon.com/cloudwatch/home?region=%s#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-%d~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'%s~source~(~'%s)~lang~'CWLI)",
 		region,
 		region,
+		int(duration.Seconds()),
 		encodedQuery,
 		encodedLogGroup,
 	)

--- a/pkg/cloudwatchclient/console_url.go
+++ b/pkg/cloudwatchclient/console_url.go
@@ -1,0 +1,23 @@
+package cloudwatchclient
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// BuildConsoleURL generates AWS Console URL for CloudWatch Logs Insights
+// query parameter should be a valid CloudWatch Logs Insights query
+// e.g. "fields @timestamp, @message | sort @timestamp desc | limit 1000"
+func BuildConsoleURL(region, logGroup, query string) string {
+	// URL encode the log group and query
+	encodedLogGroup := url.QueryEscape(logGroup)
+	encodedQuery := url.QueryEscape(query)
+
+	// Construct the URL with the Logs Insights format
+	return fmt.Sprintf("%s.console.aws.amazon.com/cloudwatch/home?region=%s#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'%s~source~(~'%s)~lang~'CWLI)",
+		region,
+		region,
+		encodedQuery,
+		encodedLogGroup,
+	)
+}

--- a/pkg/cloudwatchclient/console_url_test.go
+++ b/pkg/cloudwatchclient/console_url_test.go
@@ -1,11 +1,15 @@
 package cloudwatchclient
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestBuildConsoleURL(t *testing.T) {
 	tests := []struct {
 		name     string
 		region   string
+		duration time.Duration
 		logGroup string
 		query    string
 		want     string
@@ -13,6 +17,7 @@ func TestBuildConsoleURL(t *testing.T) {
 		{
 			name:     "basic query",
 			region:   "us-west-2",
+			duration: time.Hour,
 			logGroup: "/ecs/ecs-log-viewer-test-task",
 			query:    "fields @timestamp, @message | sort @timestamp desc | limit 1000",
 			want:     "us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields+%40timestamp%2C+%40message+%7C+sort+%40timestamp+desc+%7C+limit+1000~source~(~'%2Fecs%2Fecs-log-viewer-test-task)~lang~'CWLI)",
@@ -20,6 +25,7 @@ func TestBuildConsoleURL(t *testing.T) {
 		{
 			name:     "query with filter",
 			region:   "us-west-2",
+			duration: time.Hour,
 			logGroup: "/ecs/production-app",
 			query:    "fields @timestamp, @message | filter @message like 'error' | sort @timestamp desc",
 			want:     "us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields+%40timestamp%2C+%40message+%7C+filter+%40message+like+%27error%27+%7C+sort+%40timestamp+desc~source~(~'%2Fecs%2Fproduction-app)~lang~'CWLI)",
@@ -27,6 +33,7 @@ func TestBuildConsoleURL(t *testing.T) {
 		{
 			name:     "complex query",
 			region:   "us-east-1",
+			duration: time.Hour,
 			logGroup: "/ecs/app/prod",
 			query:    "fields @timestamp, @message, @logStream | filter @message like 'error' and @timestamp > 1234567890 | stats count(*) by bin(1h)",
 			want:     "us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields+%40timestamp%2C+%40message%2C+%40logStream+%7C+filter+%40message+like+%27error%27+and+%40timestamp+%3E+1234567890+%7C+stats+count%28%2A%29+by+bin%281h%29~source~(~'%2Fecs%2Fapp%2Fprod)~lang~'CWLI)",
@@ -35,7 +42,7 @@ func TestBuildConsoleURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildConsoleURL(tt.region, tt.logGroup, tt.query)
+			got := BuildConsoleURL(tt.region, tt.logGroup, tt.query, tt.duration)
 			if got != tt.want {
 				t.Errorf("BuildConsoleURL() = %v, want %v", got, tt.want)
 			}

--- a/pkg/cloudwatchclient/console_url_test.go
+++ b/pkg/cloudwatchclient/console_url_test.go
@@ -1,0 +1,44 @@
+package cloudwatchclient
+
+import "testing"
+
+func TestBuildConsoleURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		region   string
+		logGroup string
+		query    string
+		want     string
+	}{
+		{
+			name:     "basic query",
+			region:   "us-west-2",
+			logGroup: "/ecs/ecs-log-viewer-test-task",
+			query:    "fields @timestamp, @message | sort @timestamp desc | limit 1000",
+			want:     "us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields+%40timestamp%2C+%40message+%7C+sort+%40timestamp+desc+%7C+limit+1000~source~(~'%2Fecs%2Fecs-log-viewer-test-task)~lang~'CWLI)",
+		},
+		{
+			name:     "query with filter",
+			region:   "us-west-2",
+			logGroup: "/ecs/production-app",
+			query:    "fields @timestamp, @message | filter @message like 'error' | sort @timestamp desc",
+			want:     "us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields+%40timestamp%2C+%40message+%7C+filter+%40message+like+%27error%27+%7C+sort+%40timestamp+desc~source~(~'%2Fecs%2Fproduction-app)~lang~'CWLI)",
+		},
+		{
+			name:     "complex query",
+			region:   "us-east-1",
+			logGroup: "/ecs/app/prod",
+			query:    "fields @timestamp, @message, @logStream | filter @message like 'error' and @timestamp > 1234567890 | stats count(*) by bin(1h)",
+			want:     "us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields+%40timestamp%2C+%40message%2C+%40logStream+%7C+filter+%40message+like+%27error%27+and+%40timestamp+%3E+1234567890+%7C+stats+count%28%2A%29+by+bin%281h%29~source~(~'%2Fecs%2Fapp%2Fprod)~lang~'CWLI)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildConsoleURL(tt.region, tt.logGroup, tt.query)
+			if got != tt.want {
+				t.Errorf("BuildConsoleURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudwatchclient/query.go
+++ b/pkg/cloudwatchclient/query.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// buildCloudWatchQuery constructs a CloudWatch Logs Insights query string with proper escaping
-func buildCloudWatchQuery(streamPrefix, filter string) string {
+// BuildCloudWatchQuery constructs a CloudWatch Logs Insights query string with proper escaping
+func BuildCloudWatchQuery(streamPrefix, filter string) string {
 	// Base query that selects required fields and filters by stream prefix
 	query := fmt.Sprintf("fields @timestamp, @logStream, @message | filter @logStream like /%s/", streamPrefix)
 

--- a/pkg/cloudwatchclient/query_test.go
+++ b/pkg/cloudwatchclient/query_test.go
@@ -2,7 +2,7 @@ package cloudwatchclient
 
 import "testing"
 
-func Test_buildCloudWatchQuery(t *testing.T) {
+func Test_BuildCloudWatchQuery(t *testing.T) {
 	tests := []struct {
 		name         string
 		streamPrefix string
@@ -37,9 +37,9 @@ func Test_buildCloudWatchQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildCloudWatchQuery(tt.streamPrefix, tt.filter)
+			got := BuildCloudWatchQuery(tt.streamPrefix, tt.filter)
 			if got != tt.want {
-				t.Errorf("buildCloudWatchQuery() = %v, want %v", got, tt.want)
+				t.Errorf("BuildCloudWatchQuery() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request introduces a new feature to the `ecs-log-viewer` that allows users to open logs in the AWS Console via a web browser, in addition to querying logs directly in the terminal. The key changes include adding a new CLI flag, updating the log querying logic, and implementing helper functions for URL construction and browser opening.

### New Feature: Open Logs in AWS Console

* Added `web` flag to `AppOption` struct and `newAppOption` function to support opening logs in the AWS Console instead of the terminal (`cmd/ecs-log-viewer/app.go`). [[1]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R26) [[2]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R35)
* Implemented `openBrowser` and `open` functions to handle opening URLs in the default web browser for different operating systems (`cmd/ecs-log-viewer/app.go`).

### Log Querying Enhancements

* Modified `runApp` function to build a CloudWatch query and conditionally open the AWS Console URL if the `web` flag is set (`cmd/ecs-log-viewer/app.go`).
* Updated `QueryLogs` function to use the new query building method and removed the old `QueryLogsByStreamPrefix` method (`pkg/cloudwatchclient/client.go`).

### URL Construction for AWS Console

* Added `BuildConsoleURL` function to generate AWS Console URLs for CloudWatch Logs Insights (`pkg/cloudwatchclient/console_url.go`).
* Included unit tests for `BuildConsoleURL` to ensure correct URL generation (`pkg/cloudwatchclient/console_url_test.go`).

### Query String Construction

* Renamed `buildCloudWatchQuery` to `BuildCloudWatchQuery` and updated its usage across the codebase to reflect the new function name (`pkg/cloudwatchclient/query.go`, `pkg/cloudwatchclient/query_test.go`). [[1]](diffhunk://#diff-32428ec05280014b275e2e970489581c963a06134434b7333a7ef737cfda2043L8-R9) [[2]](diffhunk://#diff-75c75968262ef751b219786f4e70d35023268be2e2116fc46cb6e71f7157101fL5-R5) [[3]](diffhunk://#diff-75c75968262ef751b219786f4e70d35023268be2e2116fc46cb6e71f7157101fL40-R42)

### CLI Flag Addition

* Added `web` CLI flag to the main function to allow users to specify if they want to open logs in the AWS Console (`cmd/ecs-log-viewer/main.go`).