### PR TITLE
feat: added output option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--config=${workspaceFolder}/.golangci.yaml",
+        "--fast"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ ecs-log-viewer [options]
 - `--duration, -d`: Time range to fetch logs from (e.g., 24h, 1h, 30m). Defaults to last 24 hours
 - `--filter, -f`: Filter pattern to search for in log messages
 - `--fields`: Comma-separated list of log fields to display (e.g., @message,@timestamp). Default: @message
+- `--output, -o`: Output file path for saving logs. Defaults to stdout if not specified
 - `--web, -w`: Open logs in AWS CloudWatch Console instead of viewing in terminal
 
 ### Example
@@ -75,6 +76,12 @@ ecs-log-viewer --filter "error"
 
 # Display specific log fields
 ecs-log-viewer --fields @timestamp,@message,@logStream
+
+# Save logs to a file
+ecs-log-viewer --output logs.csv
+
+# Save filtered logs from the last hour to a file
+ecs-log-viewer --duration 1h --filter "error" --output error_logs.csv
 
 # Open in AWS CloudWatch Console
 ecs-log-viewer --web

--- a/cmd/ecs-log-viewer/app.go
+++ b/cmd/ecs-log-viewer/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -26,6 +27,7 @@ type AppOption struct {
 	filter   string
 	web      bool
 	fields   []string
+	output   string
 }
 
 func newAppOption(c *cli.Context) AppOption {
@@ -36,6 +38,7 @@ func newAppOption(c *cli.Context) AppOption {
 		filter:   c.String("filter"),
 		web:      c.Bool("web"),
 		fields:   c.StringSlice("fields"),
+		output:   c.String("output"),
 	}
 }
 
@@ -124,9 +127,25 @@ func runApp(c *cli.Context) error {
 		return nil
 	}
 
+	var writer io.Writer
+	if runOption.output == "" {
+		writer = os.Stdout
+	} else {
+		file, err := os.Create(runOption.output)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %v", err)
+		}
+		defer file.Close()
+		writer = file
+	}
+
 	// Write results to CSV
-	if err := cloudwatchclient.WriteLogEventsCSV(os.Stdout, results, false); err != nil {
+	if err := cloudwatchclient.WriteLogEventsCSV(writer, results, false); err != nil {
 		return fmt.Errorf("failed to write results to CSV: %v", err)
+	}
+
+	if runOption.output != "" {
+		fmt.Printf("Wrote results to CSV file: %s\n", runOption.output)
 	}
 
 	return nil

--- a/cmd/ecs-log-viewer/main.go
+++ b/cmd/ecs-log-viewer/main.go
@@ -41,6 +41,11 @@ func main() {
 				Usage: "Comma-separated list of log fields to display (e.g., @message,@timestamp). Default: @message",
 				Value: cli.NewStringSlice("@message"),
 			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Usage:   "Output file path for saving logs. Defaults to stdout if not specified.",
+			},
 			&cli.BoolFlag{
 				Name:    "web",
 				Aliases: []string{"w"},


### PR DESCRIPTION
This pull request includes changes to add an output file option to the `ecs-log-viewer` tool and updates to the VS Code settings for Go linting. The most important changes include adding the `--output` option to save logs to a file, updating the `README.md` to document the new option, and configuring the Go linter in VS Code.

### New output file option for `ecs-log-viewer`:

* [`cmd/ecs-log-viewer/app.go`](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R30): Added `output` field to `AppOption` struct, updated `newAppOption` and `runApp` functions to handle output file creation and writing logs to the specified file. [[1]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R30) [[2]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R41) [[3]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R130-R160)
* [`cmd/ecs-log-viewer/main.go`](diffhunk://#diff-38b2288a977196d03f390096de3bce8eb0fab0446c868df8785a13dfc7ac3416R44-R48): Added `--output` flag to CLI options.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62): Added documentation for the new `--output` option and examples of how to use it. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R85)

### VS Code settings for Go linting:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R7): Configured VS Code to use `golangci-lint` with a specified configuration file.