### PR TITLE
feat: add format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A CLI tool for interactively browsing and retrieving logs from AWS CloudWatch fo
 - 🕒 Configurable time range for log fetching
 - 🔐 AWS profile support for easy credential management
 - 🌍 Region-specific log viewing
+- 📄 Multiple output formats (simple, CSV, JSON)
 
 ## Installation
 
@@ -60,11 +61,27 @@ ecs-log-viewer [options]
 - `--filter, -f`: Filter pattern to search for in log messages
 - `--fields`: Comma-separated list of log fields to display (e.g., @message,@timestamp). Default: @message
 - `--output, -o`: Output file path for saving logs. Defaults to stdout if not specified
+- `--format`: Output format (simple, csv, json). Default: csv
+  - `simple`: One value per line, only available when exactly one field is selected
+  - `csv`: Comma-separated values with headers
+  - `json`: Pretty-printed JSON array of objects
 - `--web, -w`: Open logs in AWS CloudWatch Console instead of viewing in terminal
 
-### Example
+### Examples
 
 ```bash
+# View logs in CSV format (default)
+ecs-log-viewer
+
+# View only @message field in simple format
+ecs-log-viewer --fields @message --format simple
+
+# Export multiple fields in JSON format
+ecs-log-viewer --fields @message,@timestamp --format json --output logs.json
+
+# View logs from the last hour with filtering
+ecs-log-viewer --duration 1h --filter "error"
+
 # Use a specific AWS profile and region
 ecs-log-viewer --profile myprofile --region us-west-2
 

--- a/cmd/ecs-log-viewer/main.go
+++ b/cmd/ecs-log-viewer/main.go
@@ -46,6 +46,11 @@ func main() {
 				Aliases: []string{"o"},
 				Usage:   "Output file path for saving logs. Defaults to stdout if not specified.",
 			},
+			&cli.StringFlag{
+				Name:  "format",
+				Usage: "Output format (simple, csv, json). 'simple' format can only be used when exactly one field is selected",
+				Value: "simple",
+			},
 			&cli.BoolFlag{
 				Name:    "web",
 				Aliases: []string{"w"},

--- a/pkg/cloudwatchclient/writer.go
+++ b/pkg/cloudwatchclient/writer.go
@@ -2,10 +2,64 @@ package cloudwatchclient
 
 import (
 	"encoding/csv"
+	"encoding/json"
+	"fmt"
 	"io"
 
 	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 )
+
+// OutputFormat represents the supported output formats
+type OutputFormat string
+
+const (
+	formatSimple OutputFormat = "simple"
+	formatCSV    OutputFormat = "csv"
+	formatJSON   OutputFormat = "json"
+)
+
+// WriteLogEvents writes CloudWatch log events in the specified format
+func WriteLogEvents(w io.Writer, events [][]cwTypes.ResultField, format OutputFormat, writeHeader bool) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	switch format {
+	case formatSimple:
+		return WriteLogEventsSimple(w, events)
+	case formatCSV:
+		return WriteLogEventsCSV(w, events, writeHeader)
+	case formatJSON:
+		return WriteLogEventsJSON(w, events)
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+// WriteLogEventsSimple writes CloudWatch log events in a simple format (one value per line)
+// This format can only be used when exactly one field is selected
+func WriteLogEventsSimple(w io.Writer, events [][]cwTypes.ResultField) error {
+	if len(events) == 0 {
+		return nil
+	}
+	for _, event := range events {
+		for _, field := range event {
+			if *field.Field != "@ptr" {
+				if field.Value != nil {
+					if _, err := fmt.Fprintln(w, *field.Value); err != nil {
+						return err
+					}
+				} else {
+					if _, err := fmt.Fprintln(w, ""); err != nil {
+						return err
+					}
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
 
 // WriteLogEventsCSV writes CloudWatch log events to a CSV file with optional headers
 func WriteLogEventsCSV(w io.Writer, events [][]cwTypes.ResultField, writeHeader bool) error {
@@ -14,35 +68,40 @@ func WriteLogEventsCSV(w io.Writer, events [][]cwTypes.ResultField, writeHeader 
 	}
 	csvWriter := csv.NewWriter(w)
 	defer csvWriter.Flush()
-	columnCount := len(events[0]) - 1
-	if columnCount <= 0 {
-		return nil
-	}
+	columnCount := len(events[0])
 
+	var headers []string
+	// convert event field index to csv column index
+	// we need this map since we skip @ptr field
+	indexMap := make([]int, columnCount)
 	// Write header if there are events
-	if writeHeader && len(events) > 0 && len(events[0]) > 0 {
-		headers := make([]string, columnCount)
+	if len(events) > 0 && len(events[0]) > 0 {
+		headerIdx := 0
 		for i, field := range events[0] {
 			// Skip @ptr field
 			if *field.Field != "@ptr" {
-				headers[i] = *field.Field
+				indexMap[i] = headerIdx
+				headerIdx++
+				headers = append(headers, *field.Field)
 			}
 		}
-		if err := csvWriter.Write(headers); err != nil {
-			return err
+		if writeHeader {
+			if err := csvWriter.Write(headers); err != nil {
+				return err
+			}
 		}
 	}
 
 	// Write data rows
 	for _, event := range events {
-		row := make([]string, columnCount)
+		row := make([]string, len(headers))
 		for i, field := range event {
 			// Skip @ptr field
 			if *field.Field != "@ptr" {
 				if field.Value != nil {
-					row[i] = *field.Value
+					row[indexMap[i]] = *field.Value
 				} else {
-					row[i] = "" // Empty string for nil values
+					row[indexMap[i]] = "" // Empty string for nil values
 				}
 			}
 		}
@@ -52,4 +111,30 @@ func WriteLogEventsCSV(w io.Writer, events [][]cwTypes.ResultField, writeHeader 
 	}
 
 	return nil
+}
+
+// WriteLogEventsJSON writes CloudWatch log events in JSON format
+func WriteLogEventsJSON(w io.Writer, events [][]cwTypes.ResultField) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	var logs []map[string]string
+	for _, event := range events {
+		log := make(map[string]string)
+		for _, field := range event {
+			if *field.Field != "@ptr" {
+				if field.Value != nil {
+					log[*field.Field] = *field.Value
+				} else {
+					log[*field.Field] = ""
+				}
+			}
+		}
+		logs = append(logs, log)
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(logs)
 }

--- a/pkg/cloudwatchclient/writer_test.go
+++ b/pkg/cloudwatchclient/writer_test.go
@@ -1,0 +1,160 @@
+package cloudwatchclient
+
+import (
+	"bytes"
+	"testing"
+
+	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// ptr is a helper to get pointer to a string.
+func ptr(s string) *string {
+	return &s
+}
+
+// TestWriteLogEventsCSV_EmptyEvents tests that an empty events slice produces no output and no error.
+func TestWriteLogEventsCSV_EmptyEvents(t *testing.T) {
+	var buf bytes.Buffer
+	// Call with empty events slice
+	err := WriteLogEventsCSV(&buf, [][]cwTypes.ResultField{}, true)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("Expected empty output for empty events, got %q", buf.String())
+	}
+}
+
+// TestWriteLogEventsCSV_WithHeader tests that when writeHeader is true, only the header row is written.
+// Note: WriteLogEventsCSV calculates the header row based on the first event row with columnCount = len(row)-1.
+// Therefore, we construct a header row with exactly 2 fields so that columnCount becomes 1.
+func TestWriteLogEventsCSV_WithHeader(t *testing.T) {
+	var buf bytes.Buffer
+
+	events := [][]cwTypes.ResultField{
+		{
+			{Field: ptr("time"), Value: ptr("2025-02-16T00:00:00Z")},
+			{Field: ptr("level"), Value: ptr("INFO")},
+		},
+	}
+	err := WriteLogEventsCSV(&buf, events, true)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "time,level\n2025-02-16T00:00:00Z,INFO\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output %q, got %q", expected, buf.String())
+	}
+}
+
+// TestWriteLogEventsCSV_NoHeader tests that when writeHeader is false, no output is written.
+func TestWriteLogEventsCSV_NoHeader(t *testing.T) {
+	var buf bytes.Buffer
+	events := [][]cwTypes.ResultField{
+		{
+			{Field: ptr("time"), Value: ptr("2025-02-16T00:00:00Z")},
+			{Field: ptr("level"), Value: ptr("INFO")},
+		},
+	}
+
+	err := WriteLogEventsCSV(&buf, events, false)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "2025-02-16T00:00:00Z,INFO\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output %q, got %q", expected, buf.String())
+	}
+}
+
+// TestWriteLogEventsCSV_JSONValue tests that a JSON string value is written correctly.
+func TestWriteLogEventsCSV_JSONValue(t *testing.T) {
+	var buf bytes.Buffer
+	events := [][]cwTypes.ResultField{
+		{
+			{Field: ptr("time"), Value: ptr("2025-02-16T00:00:00Z")},
+			{Field: ptr("message"), Value: ptr("{\"key\": \"value\"}")},
+		},
+	}
+
+	err := WriteLogEventsCSV(&buf, events, false)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "2025-02-16T00:00:00Z,\"{\"\"key\"\": \"\"value\"\"}\"\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output %q, got %q", expected, buf.String())
+	}
+}
+
+// TestWriteLogEventsSimple tests writing events in simple format
+func TestWriteLogEventsSimple(t *testing.T) {
+	var buf bytes.Buffer
+
+	events := [][]cwTypes.ResultField{
+		{
+			{Field: ptr("message"), Value: ptr("log message 1")},
+		},
+		{
+			{Field: ptr("message"), Value: ptr("log message 2")},
+		},
+	}
+
+	err := WriteLogEventsSimple(&buf, events)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "log message 1\nlog message 2\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output %q, got %q", expected, buf.String())
+	}
+}
+
+// TestWriteLogEventsJSON tests writing events in JSON format
+func TestWriteLogEventsJSON(t *testing.T) {
+	var buf bytes.Buffer
+
+	events := [][]cwTypes.ResultField{
+		{
+			{Field: ptr("time"), Value: ptr("2025-02-16T00:00:00Z")},
+			{Field: ptr("level"), Value: ptr("INFO")},
+			{Field: ptr("message"), Value: ptr("test message")},
+		},
+	}
+
+	err := WriteLogEventsJSON(&buf, events)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "[\n  {\n    \"level\": \"INFO\",\n    \"message\": \"test message\",\n    \"time\": \"2025-02-16T00:00:00Z\"\n  }\n]\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output %q, got %q", expected, buf.String())
+	}
+}
+
+// TestWriteLogEventsJSON_ComplexValue tests writing JSON events with nested JSON values
+func TestWriteLogEventsJSON_ComplexValue(t *testing.T) {
+	var buf bytes.Buffer
+
+	events := [][]cwTypes.ResultField{
+		{
+			{Field: ptr("time"), Value: ptr("2025-02-16T00:00:00Z")},
+			{Field: ptr("data"), Value: ptr(`{"key":"value","nested":{"foo":"bar"}}`)},
+		},
+	}
+
+	err := WriteLogEventsJSON(&buf, events)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "[\n  {\n    \"data\": \"{\\\"key\\\":\\\"value\\\",\\\"nested\\\":{\\\"foo\\\":\\\"bar\\\"}}\",\n    \"time\": \"2025-02-16T00:00:00Z\"\n  }\n]\n"
+	if buf.String() != expected {
+		t.Errorf("Expected output %q, got %q", expected, buf.String())
+	}
+}


### PR DESCRIPTION
This pull request introduces multiple changes to add support for different output formats (simple, CSV, JSON) for the `ecs-log-viewer` CLI tool. The changes include updates to the documentation, command-line options, and the implementation of the new formats in the codebase.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14): Added descriptions for the new output format options and examples of how to use them. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64-R84)

### Command-line interface updates:
* [`cmd/ecs-log-viewer/main.go`](diffhunk://#diff-38b2288a977196d03f390096de3bce8eb0fab0446c868df8785a13dfc7ac3416R49-R53): Added a new `--format` flag to specify the output format.

### Code implementation updates:
* `cmd/ecs-log-viewer/app.go`:
  * Added a `format` field to the `AppOption` struct and validated the format. [[1]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R32-R47) [[2]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R59) [[3]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R156-R160)
  * Updated the `writeResults` function to handle different output formats. [[1]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L103-R120) [[2]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L123-R146) [[3]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L180-R203)

### New functionality in `cloudwatchclient` package:
* `pkg/cloudwatchclient/writer.go`:
  * Introduced `OutputFormat` type and constants for supported formats.
  * Implemented `WriteLogEvents` function to handle different formats.
  * Added specific functions for writing logs in simple, CSV, and JSON formats. [[1]](diffhunk://#diff-d8c746cd85ee425b7869a36e7857c820baac39db19cfe713cb569b79bace03c3R5-R104) [[2]](diffhunk://#diff-d8c746cd85ee425b7869a36e7857c820baac39db19cfe713cb569b79bace03c3R115-R140)

### Tests:
* [`pkg/cloudwatchclient/writer_test.go`](diffhunk://#diff-b0bd16ae14ee97899ac706c70605c38ddf023aef8a7c30acad08f468a87d487dR1-R91): Added tests for the new output format functionalities, including CSV and JSON outputs.