### PR TITLE
feat: pass taskdef and container as cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ ecs-log-viewer [options]
 - `--region, -r`: AWS region where your ECS clusters are located (can also be set via AWS_REGION environment variable)
 - `--duration, -d`: Time range to fetch logs from (e.g., 24h, 1h, 30m). Defaults to last 24 hours
 - `--filter, -f`: Filter pattern to search for in log messages
+- `--taskdef, -t`: ECS task definition family name. If not specified, you will be prompted to select one interactively
+- `--container, -c`: Container name within the task definition. If not specified, you will be prompted to select one interactively
 - `--fields`: Comma-separated list of log fields to display (e.g., @message,@timestamp). Default: @message
 - `--output, -o`: Output file path for saving logs. Defaults to stdout if not specified
 - `--format`: Output format (simple, csv, json). Default: csv

--- a/cmd/ecs-log-viewer/main.go
+++ b/cmd/ecs-log-viewer/main.go
@@ -36,6 +36,16 @@ func main() {
 				Aliases: []string{"f"},
 				Usage:   "Filter pattern to search for in log messages",
 			},
+			&cli.StringFlag{
+				Name:    "taskdef",
+				Aliases: []string{"t"},
+				Usage:   "ECS task definition family name. If not specified, you will be prompted to select one interactively",
+			},
+			&cli.StringFlag{
+				Name:    "container",
+				Aliases: []string{"c"},
+				Usage:   "Container name within the task definition. If not specified, you will be prompted to select one interactively",
+			},
 			&cli.StringSliceFlag{
 				Name:  "fields",
 				Usage: "Comma-separated list of log fields to display (e.g., @message,@timestamp). Default: @message",

--- a/pkg/ecsclient/client.go
+++ b/pkg/ecsclient/client.go
@@ -2,6 +2,7 @@ package ecsclient
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -92,7 +93,7 @@ func (e *EcsClient) DescribeLatestTaskDefinition(family TaskDefFamily) (*ecsType
 	}
 
 	if len(resp.TaskDefinitionArns) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("No task definition found for %s", family.Name)
 	}
 
 	// Get the latest task definition


### PR DESCRIPTION
This pull request introduces new options to specify ECS task definitions and container names directly, enhancing the `ecs-log-viewer` tool's usability. The most important changes include updates to the command-line interface, modifications to the application options structure, and enhancements to the task and container selection logic.

### Command-line Interface Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R63): Added `--taskdef, -t` and `--container, -c` options to specify ECS task definition family name and container name, respectively.
* [`cmd/ecs-log-viewer/main.go`](diffhunk://#diff-38b2288a977196d03f390096de3bce8eb0fab0446c868df8785a13dfc7ac3416R39-R48): Added new flags for `taskdef` and `container` with appropriate aliases and usage descriptions.

### Application Options:
* [`cmd/ecs-log-viewer/app.go`](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R28-R29): Updated `AppOption` struct to include `taskdef` and `container` fields.
* [`cmd/ecs-log-viewer/app.go`](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773R57-R58): Modified `newAppOption` function to initialize `taskdef` and `container` fields from CLI context.

### Task and Container Selection Logic:
* [`cmd/ecs-log-viewer/app.go`](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L80-R89): Enhanced `selectTaskAndContainer` function to handle direct specification of task definition family and container name, falling back to interactive selection if not provided. [[1]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L80-R89) [[2]](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L89-R129)
* [`cmd/ecs-log-viewer/app.go`](diffhunk://#diff-1778fef0c9f8181b1b1c740becb4be50ad4dba0b2c8902e9a9752ebde7da9773L169-R196): Updated `runApp` function to pass `runOption` to `selectTaskAndContainer`.

### Error Handling:
* [`pkg/ecsclient/client.go`](diffhunk://#diff-ed4877a8c4d0c0fb90d9afc72197dd52c3accf85f47c6eb1f55d0684058b22a1L95-R96): Improved error handling in `DescribeLatestTaskDefinition` to return an error if no task definitions are found.