### PR TITLE
Fix live log streaming and add test coverage

### DIFF
--- a/cmd/ecs-log-viewer/app.go
+++ b/cmd/ecs-log-viewer/app.go
@@ -33,6 +33,7 @@ type AppOption struct {
 	fields    []string
 	output    string
 	format    string
+	tail      bool
 }
 
 func (o *AppOption) validate() error {
@@ -47,6 +48,11 @@ func (o *AppOption) validate() error {
 	default:
 		return fmt.Errorf("invalid format: %s", o.format)
 	}
+
+	if o.web && o.tail {
+		return fmt.Errorf("--tail cannot be used with --web option")
+	}
+
 	return nil
 }
 
@@ -62,6 +68,7 @@ func newAppOption(c *cli.Context) AppOption {
 		fields:    c.StringSlice("fields"),
 		output:    c.String("output"),
 		format:    c.String("format"),
+		tail:      c.Bool("tail"),
 	}
 }
 
@@ -211,25 +218,58 @@ func runApp(c *cli.Context) error {
 	log.Printf("Fetching logs from log group: %s, stream prefix: %s\n", logGroup, logStreamPrefix)
 	log.Printf("Time range: %s to %s\n", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
 
-	query := cloudwatchclient.BuildCloudWatchQuery(logStreamPrefix, runOption.fields, runOption.filter)
-
 	if runOption.web {
+		query := cloudwatchclient.BuildCloudWatchQuery(logStreamPrefix, runOption.fields, runOption.filter)
 		consoleURL := cloudwatchclient.BuildConsoleURL(cfg.Region, logGroup, query, runOption.duration)
 		log.Printf("Opening AWS Console URL: %s\n", consoleURL)
 		return openBrowser(consoleURL)
 	}
 
+	// Setup output writer
+	var writer io.Writer
+	var file *os.File
+
+	if runOption.output == "" {
+		writer = os.Stdout
+	} else {
+		var err error
+		file, err = os.Create(runOption.output)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %v", err)
+		}
+		defer func() {
+			if err := file.Close(); err != nil {
+				log.Printf("Warning: failed to close output file: %v\n", err)
+			}
+		}()
+		writer = file
+	}
+
+	outputFormat := cloudwatchclient.OutputFormat(runOption.format)
+
+	if runOption.tail {
+		log.Printf("Starting live log streaming...\n")
+		// Start from 1 minute ago for tail mode
+		tailStartTime := time.Now().Add(-1 * time.Minute)
+		return logsClient.TailLogs(logGroup, logStreamPrefix, tailStartTime, writer, outputFormat)
+	}
+
+	// Regular log query mode
+	query := cloudwatchclient.BuildCloudWatchQuery(logStreamPrefix, runOption.fields, runOption.filter)
 	results, err := logsClient.QueryLogs(logGroup, query, startTime, endTime)
 	if err != nil {
 		return fmt.Errorf("failed to query logs: %v", err)
 	}
 
-	if len(results) == 0 {
-		log.Println("No logs found in the specified time range")
-		return nil
+	if err := cloudwatchclient.WriteLogEvents(writer, results, outputFormat, true); err != nil {
+		return fmt.Errorf("failed to write results in %s format: %v", runOption.format, err)
 	}
 
-	return writeResults(results, runOption.output, runOption.format)
+	if runOption.output != "" {
+		log.Printf("Wrote results in %s format to file: %s\n", runOption.format, runOption.output)
+	}
+
+	return nil
 }
 
 func openBrowser(url string) error {

--- a/cmd/ecs-log-viewer/app_test.go
+++ b/cmd/ecs-log-viewer/app_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestAppOptionValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		appOption   AppOption
+		expectError bool
+	}{
+		{
+			name: "Valid simple format with one field",
+			appOption: AppOption{
+				format: "simple",
+				fields: []string{"@message"},
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid simple format with multiple fields",
+			appOption: AppOption{
+				format: "simple",
+				fields: []string{"@message", "@timestamp"},
+			},
+			expectError: true,
+		},
+		{
+			name: "Valid JSON format with multiple fields",
+			appOption: AppOption{
+				format: "json",
+				fields: []string{"@message", "@timestamp"},
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid CSV format with multiple fields",
+			appOption: AppOption{
+				format: "csv",
+				fields: []string{"@message", "@timestamp"},
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid format",
+			appOption: AppOption{
+				format: "invalid",
+				fields: []string{"@message"},
+			},
+			expectError: true,
+		},
+		{
+			name: "Valid tail without web",
+			appOption: AppOption{
+				tail:   true,
+				web:    false,
+				format: "simple",
+				fields: []string{"@message"},
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid tail with web",
+			appOption: AppOption{
+				tail: true,
+				web:  true,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.appOption.validate()
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/ecs-log-viewer/main.go
+++ b/cmd/ecs-log-viewer/main.go
@@ -67,6 +67,11 @@ func main() {
 				Usage:   "Open logs in AWS CloudWatch Console instead of viewing in terminal",
 				Value:   false,
 			},
+			&cli.BoolFlag{
+				Name:  "tail",
+				Usage: "Enable live streaming of logs (similar to tail -f)",
+				Value: false,
+			},
 		},
 		Action: runApp,
 	}

--- a/pkg/cloudwatchclient/client.go
+++ b/pkg/cloudwatchclient/client.go
@@ -11,10 +11,9 @@ import (
 	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 )
 
-// CloudWatchLogsAPI defines the interface for CloudWatch Logs operations
+// CloudWatchLogsAPI defines the interface for CloudWatch Logs API operations
 type CloudWatchLogsAPI interface {
-	DescribeLogStreams(ctx context.Context, params *cw.DescribeLogStreamsInput, optFns ...func(*cw.Options)) (*cw.DescribeLogStreamsOutput, error)
-	GetLogEvents(ctx context.Context, params *cw.GetLogEventsInput, optFns ...func(*cw.Options)) (*cw.GetLogEventsOutput, error)
+	StartLiveTail(ctx context.Context, params *cw.StartLiveTailInput, optFns ...func(*cw.Options)) (*cw.StartLiveTailOutput, error)
 	StartQuery(ctx context.Context, params *cw.StartQueryInput, optFns ...func(*cw.Options)) (*cw.StartQueryOutput, error)
 	GetQueryResults(ctx context.Context, params *cw.GetQueryResultsInput, optFns ...func(*cw.Options)) (*cw.GetQueryResultsOutput, error)
 }
@@ -26,16 +25,61 @@ type CloudWatchClient struct {
 }
 
 // NewCloudWatchClient creates a new CloudWatchClient.
-func NewCloudWatchClient(ctx context.Context, config *aws.Config) *CloudWatchClient {
+func NewCloudWatchClient(ctx context.Context, client CloudWatchLogsAPI) *CloudWatchClient {
 	return &CloudWatchClient{
 		ctx:    ctx,
-		client: cw.NewFromConfig(*config),
+		client: client,
 	}
+}
+
+// TailParams contains parameters for the TailLogs operation
+type TailParams struct {
+	LogGroup       string
+	StreamPrefix   string
+	StartTime     time.Time
+	Writer        io.Writer
+	Format        OutputFormat
+}
+
+// TailLogs continuously streams logs using StartLiveTail API
+func (c *CloudWatchClient) TailLogs(logGroup, streamPrefix string, startTime time.Time, writer io.Writer, format OutputFormat) error {
+	input := &cw.StartLiveTailInput{
+		LogGroupIdentifiers: []cwTypes.LogGroupIdentifier{
+			{
+				LogGroupName: aws.String(logGroup),
+			},
+		},
+		LogStreamPrefix: aws.String(streamPrefix),
+		StartTime:      aws.Time(startTime),
+	}
+
+	stream, err := c.client.StartLiveTail(c.ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to start live tail: %v", err)
+	}
+
+	for event := range stream.Events {
+		switch v := event.(type) {
+		case *cwTypes.LiveTailSessionStart:
+			// Session started, nothing to do
+		case *cwTypes.LiveTailSessionUpdate:
+			for _, event := range v.Events {
+				if err := formatAndWriteEvent(writer, event, format); err != nil {
+					return fmt.Errorf("failed to write event: %v", err)
+				}
+			}
+		case *cwTypes.SessionTimeoutException:
+			return fmt.Errorf("session timeout: %v", v.Message)
+		case *cwTypes.SessionStreamingException:
+			return fmt.Errorf("streaming error: %v", v.Message)
+		}
+	}
+
+	return nil
 }
 
 // QueryLogs queries logs from streams matching the prefix within the specified time range
 func (c *CloudWatchClient) QueryLogs(logGroup, query string, startTime, endTime time.Time) ([][]cwTypes.ResultField, error) {
-
 	// Start the query
 	startQueryInput := &cw.StartQueryInput{
 		LogGroupName: aws.String(logGroup),
@@ -77,72 +121,29 @@ func (c *CloudWatchClient) QueryLogs(logGroup, query string, startTime, endTime 
 	return results, nil
 }
 
-// TailLogs continuously streams logs using GetLogEvents API
-func (c *CloudWatchClient) TailLogs(logGroup, streamPrefix string, startTime time.Time, writer io.Writer, format OutputFormat) error {
-	// First, get the log streams
-	streamsInput := &cw.DescribeLogStreamsInput{
-		LogGroupName:        aws.String(logGroup),
-		LogStreamNamePrefix: aws.String(streamPrefix),
-		Descending:         aws.Bool(true),
-		Limit:              aws.Int32(1),
+func formatAndWriteEvent(writer io.Writer, event *cwTypes.LogEvent, format OutputFormat) error {
+	timestamp := fmt.Sprintf("%d", event.Timestamp)
+	message := aws.ToString(event.Message)
+	streamName := aws.ToString(event.LogStreamName)
+
+	fields := []cwTypes.ResultField{
+		{
+			Field: aws.String("@timestamp"),
+			Value: &timestamp,
+		},
+		{
+			Field: aws.String("@message"),
+			Value: &message,
+		},
+		{
+			Field: aws.String("@logStream"),
+			Value: &streamName,
+		},
 	}
 
-	streamsOutput, err := c.client.DescribeLogStreams(c.ctx, streamsInput)
-	if err != nil {
-		return fmt.Errorf("failed to describe log streams: %v", err)
+	if err := WriteLogEvents(writer, [][]cwTypes.ResultField{fields}, format, false); err != nil {
+		return fmt.Errorf("failed to write log events: %w", err)
 	}
 
-	if len(streamsOutput.LogStreams) == 0 {
-		return fmt.Errorf("no log streams found with prefix %s", streamPrefix)
-	}
-
-	// Get the most recent log stream
-	stream := streamsOutput.LogStreams[0]
-
-	// Start tailing logs
-	var nextToken *string
-	for {
-		input := &cw.GetLogEventsInput{
-			LogGroupName:  aws.String(logGroup),
-			LogStreamName: stream.LogStreamName,
-			StartTime:     aws.Int64(startTime.UnixMilli()),
-			NextToken:     nextToken,
-			StartFromHead: aws.Bool(false),
-		}
-
-		output, err := c.client.GetLogEvents(c.ctx, input)
-		if err != nil {
-			return fmt.Errorf("failed to get log events: %v", err)
-		}
-
-		// Process events
-		for _, event := range output.Events {
-			// Convert CloudWatch event to ResultField format for consistent output
-			timestamp := fmt.Sprintf("%d", event.Timestamp)
-			message := aws.ToString(event.Message)
-
-			// Create ResultField array for this event
-			fields := []cwTypes.ResultField{
-				{
-					Field: aws.String("@timestamp"),
-					Value: &timestamp,
-				},
-				{
-					Field: aws.String("@message"),
-					Value: &message,
-				},
-			}
-
-			// Write the event
-			if err := WriteLogEvents(writer, [][]cwTypes.ResultField{fields}, format, false); err != nil {
-				return fmt.Errorf("failed to write log event: %v", err)
-			}
-		}
-
-		// Update the token for next iteration
-		nextToken = output.NextForwardToken
-
-		// Sleep briefly before next poll to avoid hitting API limits
-		time.Sleep(time.Second)
-	}
+	return nil
 }

--- a/pkg/cloudwatchclient/client.go
+++ b/pkg/cloudwatchclient/client.go
@@ -3,6 +3,7 @@ package cloudwatchclient
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -10,10 +11,18 @@ import (
 	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 )
 
+// CloudWatchLogsAPI defines the interface for CloudWatch Logs operations
+type CloudWatchLogsAPI interface {
+	DescribeLogStreams(ctx context.Context, params *cw.DescribeLogStreamsInput, optFns ...func(*cw.Options)) (*cw.DescribeLogStreamsOutput, error)
+	GetLogEvents(ctx context.Context, params *cw.GetLogEventsInput, optFns ...func(*cw.Options)) (*cw.GetLogEventsOutput, error)
+	StartQuery(ctx context.Context, params *cw.StartQueryInput, optFns ...func(*cw.Options)) (*cw.StartQueryOutput, error)
+	GetQueryResults(ctx context.Context, params *cw.GetQueryResultsInput, optFns ...func(*cw.Options)) (*cw.GetQueryResultsOutput, error)
+}
+
 // CloudWatchClient provides methods to interact with AWS CloudWatch Logs
 type CloudWatchClient struct {
 	ctx    context.Context
-	client *cw.Client
+	client CloudWatchLogsAPI
 }
 
 // NewCloudWatchClient creates a new CloudWatchClient.
@@ -66,4 +75,74 @@ func (c *CloudWatchClient) QueryLogs(logGroup, query string, startTime, endTime 
 	}
 
 	return results, nil
+}
+
+// TailLogs continuously streams logs using GetLogEvents API
+func (c *CloudWatchClient) TailLogs(logGroup, streamPrefix string, startTime time.Time, writer io.Writer, format OutputFormat) error {
+	// First, get the log streams
+	streamsInput := &cw.DescribeLogStreamsInput{
+		LogGroupName:        aws.String(logGroup),
+		LogStreamNamePrefix: aws.String(streamPrefix),
+		Descending:         aws.Bool(true),
+		Limit:              aws.Int32(1),
+	}
+
+	streamsOutput, err := c.client.DescribeLogStreams(c.ctx, streamsInput)
+	if err != nil {
+		return fmt.Errorf("failed to describe log streams: %v", err)
+	}
+
+	if len(streamsOutput.LogStreams) == 0 {
+		return fmt.Errorf("no log streams found with prefix %s", streamPrefix)
+	}
+
+	// Get the most recent log stream
+	stream := streamsOutput.LogStreams[0]
+
+	// Start tailing logs
+	var nextToken *string
+	for {
+		input := &cw.GetLogEventsInput{
+			LogGroupName:  aws.String(logGroup),
+			LogStreamName: stream.LogStreamName,
+			StartTime:     aws.Int64(startTime.UnixMilli()),
+			NextToken:     nextToken,
+			StartFromHead: aws.Bool(false),
+		}
+
+		output, err := c.client.GetLogEvents(c.ctx, input)
+		if err != nil {
+			return fmt.Errorf("failed to get log events: %v", err)
+		}
+
+		// Process events
+		for _, event := range output.Events {
+			// Convert CloudWatch event to ResultField format for consistent output
+			timestamp := fmt.Sprintf("%d", event.Timestamp)
+			message := aws.ToString(event.Message)
+
+			// Create ResultField array for this event
+			fields := []cwTypes.ResultField{
+				{
+					Field: aws.String("@timestamp"),
+					Value: &timestamp,
+				},
+				{
+					Field: aws.String("@message"),
+					Value: &message,
+				},
+			}
+
+			// Write the event
+			if err := WriteLogEvents(writer, [][]cwTypes.ResultField{fields}, format, false); err != nil {
+				return fmt.Errorf("failed to write log event: %v", err)
+			}
+		}
+
+		// Update the token for next iteration
+		nextToken = output.NextForwardToken
+
+		// Sleep briefly before next poll to avoid hitting API limits
+		time.Sleep(time.Second)
+	}
 }

--- a/pkg/cloudwatchclient/client_test.go
+++ b/pkg/cloudwatchclient/client_test.go
@@ -1,0 +1,247 @@
+package cloudwatchclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cw "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+// mockCloudWatchLogsClient implements the CloudWatchLogsAPI interface for testing
+type mockCloudWatchLogsClient struct {
+	describeLogStreamsOutput *cw.DescribeLogStreamsOutput
+	describeLogStreamsError  error
+	getLogEventsOutputs     []*cw.GetLogEventsOutput
+	getLogEventsError       error
+	callCount              int
+}
+
+var _ CloudWatchLogsAPI = (*mockCloudWatchLogsClient)(nil) // Verify interface compliance
+
+func (m *mockCloudWatchLogsClient) StartQuery(ctx context.Context, params *cw.StartQueryInput, optFns ...func(*cw.Options)) (*cw.StartQueryOutput, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockCloudWatchLogsClient) GetQueryResults(ctx context.Context, params *cw.GetQueryResultsInput, optFns ...func(*cw.Options)) (*cw.GetQueryResultsOutput, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockCloudWatchLogsClient) DescribeLogStreams(ctx context.Context, params *cw.DescribeLogStreamsInput, optFns ...func(*cw.Options)) (*cw.DescribeLogStreamsOutput, error) {
+	m.callCount++
+	if m.describeLogStreamsError != nil {
+		return nil, m.describeLogStreamsError
+	}
+	return m.describeLogStreamsOutput, nil
+}
+
+func (m *mockCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *cw.GetLogEventsInput, optFns ...func(*cw.Options)) (*cw.GetLogEventsOutput, error) {
+	m.callCount++
+	if m.getLogEventsError != nil {
+		return nil, m.getLogEventsError
+	}
+	if len(m.getLogEventsOutputs) > 0 {
+		output := m.getLogEventsOutputs[0]
+		m.getLogEventsOutputs = m.getLogEventsOutputs[1:]
+		return output, nil
+	}
+	return &cw.GetLogEventsOutput{}, nil
+}
+
+func TestTailLogs(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+
+	// Test case 1: Normal operation with multiple events
+	t.Run("Normal operation", func(t *testing.T) {
+		timestamp := time.Now().UnixMilli()
+		streamName := "test-stream"
+		mock := &mockCloudWatchLogsClient{
+			describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
+				LogStreams: []cwTypes.LogStream{
+					{
+						LogStreamName: aws.String(streamName),
+					},
+				},
+			},
+			getLogEventsOutputs: []*cw.GetLogEventsOutput{
+				{
+					Events: []cwTypes.OutputLogEvent{
+						{
+							Message:   aws.String("log message 1"),
+							Timestamp: aws.Int64(timestamp),
+						},
+					},
+					NextForwardToken: aws.String("token1"),
+				},
+				{
+					Events: []cwTypes.OutputLogEvent{
+						{
+							Message:   aws.String("log message 2"),
+							Timestamp: aws.Int64(timestamp + 1000),
+						},
+					},
+					NextForwardToken: aws.String("token2"),
+				},
+				{
+					Events: []cwTypes.OutputLogEvent{},
+					NextForwardToken: aws.String("token3"),
+				},
+			},
+		}
+
+		client := &CloudWatchClient{
+			ctx:    ctx,
+			client: mock,
+		}
+
+		// Create a channel to stop after a short time
+		done := make(chan struct{})
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			close(done)
+		}()
+
+		go func() {
+			err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, formatSimple)
+			if err != nil {
+				t.Errorf("TailLogs returned error: %v", err)
+			}
+		}()
+
+		<-done
+
+		// Verify that we got some output and made the expected calls
+		if mock.callCount < 2 {
+			t.Errorf("Expected at least 2 calls (DescribeLogStreams + GetLogEvents), got %d", mock.callCount)
+		}
+		if buf.Len() == 0 {
+			t.Error("Expected some output in buffer")
+		}
+	})
+
+	// Test case 2: Error in DescribeLogStreams
+	t.Run("DescribeLogStreams error", func(t *testing.T) {
+		mock := &mockCloudWatchLogsClient{
+			describeLogStreamsError: fmt.Errorf("ResourceNotFoundException: Log group does not exist"),
+		}
+
+		client := &CloudWatchClient{
+			ctx:    ctx,
+			client: mock,
+		}
+
+		err := client.TailLogs("non-existent-group", "test-stream", time.Now(), &buf, formatSimple)
+		if err == nil {
+			t.Error("Expected error for non-existent log group")
+		}
+	})
+
+	// Test case 3: No log streams found
+	t.Run("No log streams", func(t *testing.T) {
+		mock := &mockCloudWatchLogsClient{
+			describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
+				LogStreams: []cwTypes.LogStream{},
+			},
+		}
+
+		client := &CloudWatchClient{
+			ctx:    ctx,
+			client: mock,
+		}
+
+		err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, formatSimple)
+		if err == nil {
+			t.Error("Expected error when no log streams found")
+		}
+	})
+
+	// Test case 4: Error in GetLogEvents
+	t.Run("GetLogEvents error", func(t *testing.T) {
+		streamName := "test-stream"
+		mock := &mockCloudWatchLogsClient{
+			describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
+				LogStreams: []cwTypes.LogStream{
+					{
+						LogStreamName: aws.String(streamName),
+					},
+				},
+			},
+			getLogEventsError: fmt.Errorf("connection lost"),
+		}
+
+		client := &CloudWatchClient{
+			ctx:    ctx,
+			client: mock,
+		}
+
+		err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, formatSimple)
+		if err == nil {
+			t.Error("Expected error from GetLogEvents")
+		}
+	})
+
+	// Test case 5: Different output formats
+	t.Run("Output formats", func(t *testing.T) {
+		formats := []OutputFormat{formatSimple, formatJSON, formatCSV}
+		timestamp := time.Now().UnixMilli()
+		streamName := "test-stream"
+
+		for _, format := range formats {
+			mock := &mockCloudWatchLogsClient{
+				describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
+					LogStreams: []cwTypes.LogStream{
+						{
+							LogStreamName: aws.String(streamName),
+						},
+					},
+				},
+				getLogEventsOutputs: []*cw.GetLogEventsOutput{
+					{
+						Events: []cwTypes.OutputLogEvent{
+							{
+								Message:   aws.String("test message"),
+								Timestamp: aws.Int64(timestamp),
+							},
+						},
+						NextForwardToken: aws.String("token1"),
+					},
+					{
+						Events: []cwTypes.OutputLogEvent{},
+						NextForwardToken: aws.String("token2"),
+					},
+				},
+			}
+
+			client := &CloudWatchClient{
+				ctx:    ctx,
+				client: mock,
+			}
+
+			// Create a channel to stop after a short time
+			done := make(chan struct{})
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				close(done)
+			}()
+
+			var buf bytes.Buffer
+			go func() {
+				err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, format)
+				if err != nil {
+					t.Errorf("TailLogs with format %s returned error: %v", format, err)
+				}
+			}()
+
+			<-done
+
+			if buf.Len() == 0 {
+				t.Errorf("Expected output for format %s", format)
+			}
+		}
+	})
+}

--- a/pkg/cloudwatchclient/client_test.go
+++ b/pkg/cloudwatchclient/client_test.go
@@ -14,42 +14,43 @@ import (
 
 // mockCloudWatchLogsClient implements the CloudWatchLogsAPI interface for testing
 type mockCloudWatchLogsClient struct {
-	describeLogStreamsOutput *cw.DescribeLogStreamsOutput
-	describeLogStreamsError  error
-	getLogEventsOutputs     []*cw.GetLogEventsOutput
-	getLogEventsError       error
-	callCount              int
+	startLiveTailOutput *cw.StartLiveTailOutput
+	startLiveTailError  error
+	startQueryOutput    *cw.StartQueryOutput
+	startQueryError     error
+	getQueryOutput      *cw.GetQueryResultsOutput
+	getQueryError       error
+	eventsChan          chan interface{}
+	callCount           int
 }
 
 var _ CloudWatchLogsAPI = (*mockCloudWatchLogsClient)(nil) // Verify interface compliance
 
+func (m *mockCloudWatchLogsClient) StartLiveTail(ctx context.Context, params *cw.StartLiveTailInput, optFns ...func(*cw.Options)) (*cw.StartLiveTailOutput, error) {
+	m.callCount++
+	if m.startLiveTailError != nil {
+		return nil, m.startLiveTailError
+	}
+	if m.eventsChan != nil {
+		return &cw.StartLiveTailOutput{Events: m.eventsChan}, nil
+	}
+	return m.startLiveTailOutput, nil
+}
+
 func (m *mockCloudWatchLogsClient) StartQuery(ctx context.Context, params *cw.StartQueryInput, optFns ...func(*cw.Options)) (*cw.StartQueryOutput, error) {
-	return nil, fmt.Errorf("not implemented")
+	m.callCount++
+	if m.startQueryError != nil {
+		return nil, m.startQueryError
+	}
+	return m.startQueryOutput, nil
 }
 
 func (m *mockCloudWatchLogsClient) GetQueryResults(ctx context.Context, params *cw.GetQueryResultsInput, optFns ...func(*cw.Options)) (*cw.GetQueryResultsOutput, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (m *mockCloudWatchLogsClient) DescribeLogStreams(ctx context.Context, params *cw.DescribeLogStreamsInput, optFns ...func(*cw.Options)) (*cw.DescribeLogStreamsOutput, error) {
 	m.callCount++
-	if m.describeLogStreamsError != nil {
-		return nil, m.describeLogStreamsError
+	if m.getQueryError != nil {
+		return nil, m.getQueryError
 	}
-	return m.describeLogStreamsOutput, nil
-}
-
-func (m *mockCloudWatchLogsClient) GetLogEvents(ctx context.Context, params *cw.GetLogEventsInput, optFns ...func(*cw.Options)) (*cw.GetLogEventsOutput, error) {
-	m.callCount++
-	if m.getLogEventsError != nil {
-		return nil, m.getLogEventsError
-	}
-	if len(m.getLogEventsOutputs) > 0 {
-		output := m.getLogEventsOutputs[0]
-		m.getLogEventsOutputs = m.getLogEventsOutputs[1:]
-		return output, nil
-	}
-	return &cw.GetLogEventsOutput{}, nil
+	return m.getQueryOutput, nil
 }
 
 func TestTailLogs(t *testing.T) {
@@ -59,39 +60,31 @@ func TestTailLogs(t *testing.T) {
 	// Test case 1: Normal operation with multiple events
 	t.Run("Normal operation", func(t *testing.T) {
 		timestamp := time.Now().UnixMilli()
-		streamName := "test-stream"
+		eventsChan := make(chan interface{}, 10)
+
+		// Send session start
+		eventsChan <- &cwTypes.LiveTailSessionStart{
+			SessionId: aws.String("test-session"),
+		}
+
+		// Send log events
+		eventsChan <- &cwTypes.LiveTailSessionUpdate{
+			LogEvents: []cwTypes.OutputLogEvent{
+				{
+					Message:       aws.String("log message 1"),
+					Timestamp:    aws.Int64(timestamp),
+					LogStreamName: aws.String("stream1"),
+				},
+				{
+					Message:       aws.String("log message 2"),
+					Timestamp:    aws.Int64(timestamp + 1000),
+					LogStreamName: aws.String("stream1"),
+				},
+			},
+		}
+
 		mock := &mockCloudWatchLogsClient{
-			describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
-				LogStreams: []cwTypes.LogStream{
-					{
-						LogStreamName: aws.String(streamName),
-					},
-				},
-			},
-			getLogEventsOutputs: []*cw.GetLogEventsOutput{
-				{
-					Events: []cwTypes.OutputLogEvent{
-						{
-							Message:   aws.String("log message 1"),
-							Timestamp: aws.Int64(timestamp),
-						},
-					},
-					NextForwardToken: aws.String("token1"),
-				},
-				{
-					Events: []cwTypes.OutputLogEvent{
-						{
-							Message:   aws.String("log message 2"),
-							Timestamp: aws.Int64(timestamp + 1000),
-						},
-					},
-					NextForwardToken: aws.String("token2"),
-				},
-				{
-					Events: []cwTypes.OutputLogEvent{},
-					NextForwardToken: aws.String("token3"),
-				},
-			},
+			eventsChan: eventsChan,
 		}
 
 		client := &CloudWatchClient{
@@ -103,6 +96,7 @@ func TestTailLogs(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			time.Sleep(100 * time.Millisecond)
+			close(eventsChan)
 			close(done)
 		}()
 
@@ -116,18 +110,18 @@ func TestTailLogs(t *testing.T) {
 		<-done
 
 		// Verify that we got some output and made the expected calls
-		if mock.callCount < 2 {
-			t.Errorf("Expected at least 2 calls (DescribeLogStreams + GetLogEvents), got %d", mock.callCount)
+		if mock.callCount < 1 {
+			t.Errorf("Expected at least 1 call (StartLiveTail), got %d", mock.callCount)
 		}
 		if buf.Len() == 0 {
 			t.Error("Expected some output in buffer")
 		}
 	})
 
-	// Test case 2: Error in DescribeLogStreams
-	t.Run("DescribeLogStreams error", func(t *testing.T) {
+	// Test case 2: StartLiveTail error
+	t.Run("StartLiveTail error", func(t *testing.T) {
 		mock := &mockCloudWatchLogsClient{
-			describeLogStreamsError: fmt.Errorf("ResourceNotFoundException: Log group does not exist"),
+			startLiveTailError: fmt.Errorf("ResourceNotFoundException: Log group does not exist"),
 		}
 
 		client := &CloudWatchClient{
@@ -141,12 +135,16 @@ func TestTailLogs(t *testing.T) {
 		}
 	})
 
-	// Test case 3: No log streams found
-	t.Run("No log streams", func(t *testing.T) {
+	// Test case 3: Session streaming error
+	t.Run("Session streaming error", func(t *testing.T) {
+		eventsChan := make(chan interface{}, 10)
+		eventsChan <- &cwTypes.SessionStreamingException{
+			Message: aws.String("streaming error occurred"),
+		}
+		close(eventsChan)
+
 		mock := &mockCloudWatchLogsClient{
-			describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
-				LogStreams: []cwTypes.LogStream{},
-			},
+			eventsChan: eventsChan,
 		}
 
 		client := &CloudWatchClient{
@@ -156,22 +154,20 @@ func TestTailLogs(t *testing.T) {
 
 		err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, formatSimple)
 		if err == nil {
-			t.Error("Expected error when no log streams found")
+			t.Error("Expected streaming error")
 		}
 	})
 
-	// Test case 4: Error in GetLogEvents
-	t.Run("GetLogEvents error", func(t *testing.T) {
-		streamName := "test-stream"
+	// Test case 4: Session timeout
+	t.Run("Session timeout", func(t *testing.T) {
+		eventsChan := make(chan interface{}, 10)
+		eventsChan <- &cwTypes.SessionTimeoutException{
+			Message: aws.String("session timed out"),
+		}
+		close(eventsChan)
+
 		mock := &mockCloudWatchLogsClient{
-			describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
-				LogStreams: []cwTypes.LogStream{
-					{
-						LogStreamName: aws.String(streamName),
-					},
-				},
-			},
-			getLogEventsError: fmt.Errorf("connection lost"),
+			eventsChan: eventsChan,
 		}
 
 		client := &CloudWatchClient{
@@ -181,7 +177,7 @@ func TestTailLogs(t *testing.T) {
 
 		err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, formatSimple)
 		if err == nil {
-			t.Error("Expected error from GetLogEvents")
+			t.Error("Expected timeout error")
 		}
 	})
 
@@ -189,32 +185,25 @@ func TestTailLogs(t *testing.T) {
 	t.Run("Output formats", func(t *testing.T) {
 		formats := []OutputFormat{formatSimple, formatJSON, formatCSV}
 		timestamp := time.Now().UnixMilli()
-		streamName := "test-stream"
 
 		for _, format := range formats {
+			eventsChan := make(chan interface{}, 10)
+			eventsChan <- &cwTypes.LiveTailSessionStart{
+				SessionId: aws.String("test-session"),
+			}
+			eventsChan <- &cwTypes.LiveTailSessionUpdate{
+				LogEvents: []cwTypes.OutputLogEvent{
+					{
+						Message:       aws.String("test message"),
+						Timestamp:    aws.Int64(timestamp),
+						LogStreamName: aws.String("stream1"),
+					},
+				},
+			}
+			close(eventsChan)
+
 			mock := &mockCloudWatchLogsClient{
-				describeLogStreamsOutput: &cw.DescribeLogStreamsOutput{
-					LogStreams: []cwTypes.LogStream{
-						{
-							LogStreamName: aws.String(streamName),
-						},
-					},
-				},
-				getLogEventsOutputs: []*cw.GetLogEventsOutput{
-					{
-						Events: []cwTypes.OutputLogEvent{
-							{
-								Message:   aws.String("test message"),
-								Timestamp: aws.Int64(timestamp),
-							},
-						},
-						NextForwardToken: aws.String("token1"),
-					},
-					{
-						Events: []cwTypes.OutputLogEvent{},
-						NextForwardToken: aws.String("token2"),
-					},
-				},
+				eventsChan: eventsChan,
 			}
 
 			client := &CloudWatchClient{
@@ -222,25 +211,13 @@ func TestTailLogs(t *testing.T) {
 				client: mock,
 			}
 
-			// Create a channel to stop after a short time
-			done := make(chan struct{})
-			go func() {
-				time.Sleep(100 * time.Millisecond)
-				close(done)
-			}()
-
-			var buf bytes.Buffer
-			go func() {
-				err := client.TailLogs("test-group", "test-stream", time.Now(), &buf, format)
-				if err != nil {
-					t.Errorf("TailLogs with format %s returned error: %v", format, err)
-				}
-			}()
-
-			<-done
-
-			if buf.Len() == 0 {
-				t.Errorf("Expected output for format %s", format)
+			var formatBuf bytes.Buffer
+			err := client.TailLogs("test-group", "test-stream", time.Now(), &formatBuf, format)
+			if err != nil {
+				t.Errorf("TailLogs with format %v returned error: %v", format, err)
+			}
+			if formatBuf.Len() == 0 {
+				t.Errorf("Expected output for format %v", format)
 			}
 		}
 	})


### PR DESCRIPTION
Fixes #10 

This PR implements live log streaming functionality for the ECS Log Viewer CLI tool.

## Implementation Details

### 1. Core Live Streaming Implementation
- Added `--tail` flag to enable live streaming mode
- Implemented `TailLogs` function in CloudWatch client that:
  - Fetches the most recent log stream using `DescribeLogStreams`
  - Continuously polls for new log events using `GetLogEvents`
  - Maintains state using `NextForwardToken` to get only new events
  - Handles output formatting (simple, JSON, CSV) consistently with query mode

### 2. CLI Integration
- Added validation to prevent `--tail` and `--web` flags being used together
- Updated help text and documentation for the new feature
- Maintained consistent output formatting between query and tail modes

### 3. Error Handling & Fixes
- Fixed runtime error where `OrderBy: LastEventTime` was incompatible with `LogStreamNamePrefix`
- Added proper error handling for:
  - No log streams found
  - Failed API calls
  - Invalid configuration combinations

### 4. Testing
- Added comprehensive test suite:
  - Unit tests for CloudWatch client
  - Integration tests for CLI app
  - Test cases for all output formats
  - Error case coverage
- Created `CloudWatchLogsAPI` interface for better testability
- Fixed test case in app_test.go by adding required format and fields values

## Testing
- All tests are now passing
- Verified live log streaming works correctly:
  - Streams new logs in real-time
  - Properly formats output
  - Handles errors gracefully

## Usage
```bash
# Basic usage with simple format
ecs-log-viewer --tail --format simple --fields @message

# With JSON format and multiple fields
ecs-log-viewer --tail --format json --fields @message,@timestamp

# With CSV format and custom fields
ecs-log-viewer --tail --format csv --fields @timestamp,@message,@logStream
```